### PR TITLE
Fix TypeScript errors related to socket.io and RefObject types

### DIFF
--- a/app/components/StreamerInterface.tsx
+++ b/app/components/StreamerInterface.tsx
@@ -1,4 +1,3 @@
-// components/StreamerInterface.tsx
 import React, { useEffect, useRef, useState } from 'react';
 import VideoDisplay from './VideoDisplay';
 import CodeEditor from './CodeEditor';
@@ -7,19 +6,20 @@ import ProfileSetup from './ProfileSetup';
 import CashTagDisplay from './CashTagDisplay';
 import RoomIdDisplay from './RoomIdDisplay';
 import io from 'socket.io-client';
+import { Socket } from 'socket.io-client';
 
 interface StreamerInterfaceProps {
     roomId: string;
 }
 
 const StreamerInterface: React.FC<StreamerInterfaceProps> = ({ roomId }) => {
-    const localVideoRef = useRef<HTMLVideoElement>(null);
+    const localVideoRef = useRef<HTMLVideoElement | null>(null);
     const [localStream, setLocalStream] = useState<MediaStream | null>(null);
     const [transcription, setTranscription] = useState<string>('');
     const [code, setCode] = useState<string>('');
     const [profile, setProfile] = useState<{ name: string; cashTags: string }>({ name: '', cashTags: '' });
 
-    const socketRef = useRef<SocketIOClient.Socket | null>(null);
+    const socketRef = useRef<Socket | null>(null);
 
     useEffect(() => {
         socketRef.current = io('http://localhost:3001'); // Replace with your signaling server URL

--- a/app/components/ViewerInterface.tsx
+++ b/app/components/ViewerInterface.tsx
@@ -1,4 +1,3 @@
-// components/ViewerInterface.tsx
 import React, { useEffect, useRef, useState } from 'react';
 import VideoDisplay from './VideoDisplay';
 import TranscriptionDisplay from './TranscriptionDisplay';
@@ -6,19 +5,20 @@ import CodeEditor from './CodeEditor';
 import CashTagDisplay from './CashTagDisplay';
 import RoomIdDisplay from './RoomIdDisplay';
 import io from 'socket.io-client';
+import { Socket } from 'socket.io-client';
 
 interface ViewerInterfaceProps {
     roomId: string;
 }
 
 const ViewerInterface: React.FC<ViewerInterfaceProps> = ({ roomId }) => {
-    const remoteVideoRef = useRef<HTMLVideoElement>(null);
+    const remoteVideoRef = useRef<HTMLVideoElement | null>(null);
     const [remoteStream, setRemoteStream] = useState<MediaStream | null>(null);
     const [transcription, setTranscription] = useState<string>('');
     const [code, setCode] = useState<string>('');
     const [streamerProfile, setStreamerProfile] = useState<{ name: string; cashTags: string }>({ name: '', cashTags: '' });
 
-    const socketRef = useRef<SocketIOClient.Socket | null>(null);
+    const socketRef = useRef<Socket | null>(null);
 
     useEffect(() => {
         socketRef.current = io('http://localhost:3001'); // Replace with your signaling server URL

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,5 @@
-// server/index.ts (Example using Socket.io and TypeScript)
 import { createServer } from 'http';
-import { Server } from 'socket.io';
+import { Server, Socket } from 'socket.io';
 
 const httpServer = createServer();
 const io = new Server(httpServer, {
@@ -17,7 +16,7 @@ interface Room {
 
 const rooms: Record<string, Room> = {};
 
-io.on('connection', (socket) => {
+io.on('connection', (socket: Socket) => {
     console.log('User connected:', socket.id);
 
     socket.on('join-room', (roomId: string) => {


### PR DESCRIPTION
Resolve TypeScript errors related to 'socket.io' module, 'SocketIOClient' namespace, and 'RefObject<HTMLVideoElement | null>' type assignment.

* **server/index.ts**
  - Import `socket.io` types from `socket.io`.
  - Explicitly type the `socket` parameter in the `connection` event.

* **app/components/ViewerInterface.tsx**
  - Import `Socket` from `socket.io-client`.
  - Update `remoteVideoRef` type to `React.RefObject<HTMLVideoElement | null>`.
  - Update `socketRef` type to `Socket | null`.

* **app/components/StreamerInterface.tsx**
  - Import `Socket` from `socket.io-client`.
  - Update `localVideoRef` type to `React.RefObject<HTMLVideoElement | null>`.
  - Update `socketRef` type to `Socket | null`.

